### PR TITLE
docs: add limitation about the Matomo's `Live.getLastVisitsDetails` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,14 @@ Migrations run automatically on each `pnpm start` to ensure schema compatibility
    - Parallel event insertion (configurable)
    - Automatic pagination for large datasets
 
+## ⚠️ Limitations
+
+### Actions per visit cap
+
+The Matomo `Live.getLastVisitsDetails` API limits the number of actions returned per visit to **99**.
+If a user performed more than **99** actions during a visit, the extra actions will be missing from the database (see [issue #92](https://github.com/SocialGouv/matomo-postgres/issues/92)).
+This limitation comes from Matomo’s API itself; this library does not implement any per-action workaround.
+
 ## 🐛 Troubleshooting
 
 ### Common Issues


### PR DESCRIPTION
Linked to https://github.com/SocialGouv/matomo-postgres/issues/92

La vérification est assez simple. 

Il faut de se connecter à la BDD est exécuter la requête, `SELECT MAX(actions) FROM public.matomo_partitioned;`. Le résultat est `99`.
Ensuite se rendre sur le matomo, est dans Visiteurs > Logiciel > Exporter les navigateurs en CSV, et regarder la colonne `Nombre maximum d'actions en une visite`. Sur le CDTN :  

<img width="1930" height="428" alt="CleanShot 2026-04-07 at 10 46 18@2x" src="https://github.com/user-attachments/assets/46f519ee-c936-4290-b0eb-6887abb5aa20" />

On voit qu'on a des visites avec plus de 700 actions (bots) et seulement 99 max dans la base de données.
