### PR TITLE
feat: add A/B Testing data (experiments)

### DIFF
--- a/src/__tests__/__snapshots__/importEvent.test.ts.snap
+++ b/src/__tests__/__snapshots__/importEvent.test.ts.snap
@@ -29,6 +29,16 @@ exports[`getEventsFromMatomoVisit: should merge action events 1`] = `
     "dimension7": "v1.2.3",
     "dimension8": "fr",
     "dimension9": "light",
+    "experiments": [
+      {
+        "idexperiment": "3",
+        "name": "search_ab_test",
+        "variation": {
+          "idvariation": 5,
+          "name": "search_v2",
+        },
+      },
+    ],
     "idsite": "42",
     "idvisit": "124",
     "operatingsystemname": "Mac",
@@ -87,6 +97,16 @@ exports[`getEventsFromMatomoVisit: should merge action events 1`] = `
     "dimension7": "v1.2.3",
     "dimension8": "fr",
     "dimension9": "light",
+    "experiments": [
+      {
+        "idexperiment": "3",
+        "name": "search_ab_test",
+        "variation": {
+          "idvariation": 5,
+          "name": "search_v2",
+        },
+      },
+    ],
     "idsite": "42",
     "idvisit": "124",
     "operatingsystemname": "Mac",
@@ -142,6 +162,16 @@ exports[`getEventsFromMatomoVisit: should merge action events 1`] = `
     "dimension7": "v1.2.3",
     "dimension8": "fr",
     "dimension9": "light",
+    "experiments": [
+      {
+        "idexperiment": "3",
+        "name": "search_ab_test",
+        "variation": {
+          "idvariation": 5,
+          "name": "search_v2",
+        },
+      },
+    ],
     "idsite": "42",
     "idvisit": "124",
     "operatingsystemname": "Mac",

--- a/src/__tests__/__snapshots__/run.test.ts.snap
+++ b/src/__tests__/__snapshots__/run.test.ts.snap
@@ -52,15 +52,21 @@ exports[`run: should fetch the latest 5 days on matomo 1`] = `
 
 exports[`run: should fetch the latest event date if no date provided 1`] = `
 [
-  "select count(distinct "idvisit") as "count" from "matomo" where date(timezone('UTC', action_timestamp)) = $1",
+  "select action_timestamp at time zone 'UTC' as "action_timestamp" from "matomo" order by "action_timestamp" desc limit $1",
   [
-    "2023-03-29",
+    1,
   ],
 ]
 `;
 
 exports[`run: should run SQL queries 1`] = `
 [
+  [
+    "select action_timestamp at time zone 'UTC' as "action_timestamp" from "matomo" order by "action_timestamp" desc limit $1",
+    [
+      1,
+    ],
+  ],
   [
     "select count(distinct "idvisit") as "count" from "matomo" where date(timezone('UTC', action_timestamp)) = $1",
     [
@@ -111,9 +117,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -174,6 +181,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
   [
@@ -220,9 +237,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -280,6 +298,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
   [
@@ -326,9 +354,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -386,6 +415,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
   [
@@ -432,9 +471,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -495,6 +535,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
   [
@@ -541,9 +591,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -601,6 +652,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
   [
@@ -647,9 +708,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -707,6 +769,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
   [
@@ -759,9 +831,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -822,6 +895,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
   [
@@ -868,9 +951,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -928,6 +1012,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
   [
@@ -974,9 +1068,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -1034,6 +1129,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
   [
@@ -1080,9 +1185,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -1143,6 +1249,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
   [
@@ -1189,9 +1305,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -1249,6 +1366,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
   [
@@ -1295,9 +1422,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -1355,6 +1483,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
   [
@@ -1407,9 +1545,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -1470,6 +1609,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
   [
@@ -1516,9 +1665,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -1576,6 +1726,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
   [
@@ -1622,9 +1782,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -1682,6 +1843,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
   [
@@ -1728,9 +1899,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -1791,6 +1963,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
   [
@@ -1837,9 +2019,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -1897,6 +2080,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
   [
@@ -1943,9 +2136,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -2003,6 +2197,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
   [
@@ -2055,9 +2259,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -2118,6 +2323,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
   [
@@ -2164,9 +2379,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -2224,6 +2440,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
   [
@@ -2270,9 +2496,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -2330,6 +2557,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
   [
@@ -2376,9 +2613,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -2439,6 +2677,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
   [
@@ -2485,9 +2733,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -2545,6 +2794,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
   [
@@ -2591,9 +2850,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -2651,6 +2911,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
   [
@@ -2703,9 +2973,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -2766,6 +3037,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
   [
@@ -2812,9 +3093,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -2872,6 +3154,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
   [
@@ -2918,9 +3210,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -2978,6 +3271,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
   [
@@ -3024,9 +3327,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -3087,6 +3391,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
   [
@@ -3133,9 +3447,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -3193,6 +3508,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
   [
@@ -3239,9 +3564,10 @@ exports[`run: should run SQL queries 1`] = `
 "visitorid",
 "referrertype",
 "referrername",
-"resolution"
+"resolution",
+"experiments"
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43
         )
         ON CONFLICT (action_id) DO NOTHING
       ",
@@ -3299,6 +3625,16 @@ exports[`run: should run SQL queries 1`] = `
       "referrerType",
       "referrerName",
       "1920x1080",
+      [
+        {
+          "idexperiment": "3",
+          "name": "search_ab_test",
+          "variation": {
+            "idvariation": 5,
+            "name": "search_v2",
+          },
+        },
+      ],
     ],
   ],
 ]

--- a/src/__tests__/visit.json
+++ b/src/__tests__/visit.json
@@ -17,6 +17,16 @@
   "region": "Buenos Aires",
   "city": "Buenos Aires",
   "resolution": "1920x1080",
+  "experiments": [
+    {
+      "idexperiment": "3",
+      "name": "search_ab_test",
+      "variation": {
+        "idvariation": 5,
+        "name": "search_v2"
+      }
+    }
+  ],
   "dimension1": "guest",
   "dimension3": "page",
   "dimension6": "shop",

--- a/src/importEvent.ts
+++ b/src/importEvent.ts
@@ -243,7 +243,7 @@ export const getEventsFromMatomoVisit = (
         (a, prop) => ({ ...a, [prop.toLowerCase()]: matomoVisit[prop] }),
         {}
       ),
-      experiments: JSON.stringify(matomoVisit.experiments),
+      experiments: matomoVisit.experiments ?? null,
       serverdateprettyfirstaction: new Date(
         (matomoVisit.firstActionTimestamp || 0) * 1000
       ).toISOString(),
@@ -294,5 +294,5 @@ type AllMatomoActionDetailKeys =
 type MatomoActionDetail = Partial<
   Record<AllMatomoActionDetailKeys, string> & { usercustomproperties: any } & {
     usercustomdimensions: any
-  }
+  } & { experiments: any }
 >

--- a/src/importEvent.ts
+++ b/src/importEvent.ts
@@ -46,7 +46,8 @@ const MATOMO_INSERT_COLUMNS = [
   'visitorid',
   'referrertype',
   'referrername',
-  'resolution'
+  'resolution',
+  'experiments'
 ] as const
 
 const MATOMO_INSERT_COLUMN_SQL = sql.join(
@@ -111,7 +112,8 @@ export const importEvent = async (event: MatomoActionDetail): Promise<void> => {
     visitorid: event.visitorid ?? null,
     referrertype: event.referrertype ?? null,
     referrername: event.referrername ?? null,
-    resolution: event.resolution ?? null
+    resolution: event.resolution ?? null,
+    experiments: event.experiments ?? null
   }
 
   // Minimal runtime validation for required fields
@@ -241,6 +243,7 @@ export const getEventsFromMatomoVisit = (
         (a, prop) => ({ ...a, [prop.toLowerCase()]: matomoVisit[prop] }),
         {}
       ),
+      experiments: JSON.stringify(matomoVisit.experiments),
       serverdateprettyfirstaction: new Date(
         (matomoVisit.firstActionTimestamp || 0) * 1000
       ).toISOString(),
@@ -286,6 +289,7 @@ type AllMatomoActionDetailKeys =
   | 'usercustomproperties'
   | 'usercustomdimensions'
   | 'serverdateprettyfirstaction'
+  | 'experiments'
 
 type MatomoActionDetail = Partial<
   Record<AllMatomoActionDetailKeys, string> & { usercustomproperties: any } & {

--- a/src/migrations/20260407-01-ab-testing.ts
+++ b/src/migrations/20260407-01-ab-testing.ts
@@ -1,4 +1,4 @@
-import { Kysely } from 'kysely'
+import { Kysely, sql } from 'kysely'
 
 const MATOMO_TABLE_NAME = process.env.MATOMO_TABLE_NAME || 'matomo'
 const PARTITIONED_MATOMO_TABLE_NAME =
@@ -14,9 +14,318 @@ export async function up(db: Kysely<any>): Promise<void> {
     .alterTable(PARTITIONED_MATOMO_TABLE_NAME)
     .addColumn('experiments', 'jsonb')
     .execute()
+
+  // Drop the previous version of the stored procedure so the signature can grow
+  // (CREATE OR REPLACE refuses to change parameter lists in PL/pgSQL).
+  await sql`DROP FUNCTION IF EXISTS insert_into_matomo_partitioned(
+    text, timestamptz, text, text, text, text, text, text, text, text, text,
+    text, text, text, text, text, date, text, text, text, text, numeric, text,
+    json, json, text, text, text, text, text, text, text, text, text, text,
+    text, text, text, text, text, text, text
+  )`.execute(db)
+
+  await sql`
+    CREATE OR REPLACE FUNCTION insert_into_matomo_partitioned(
+      p_action_id text,
+      p_action_timestamp timestamptz,
+      p_idsite text DEFAULT '',
+      p_idvisit text DEFAULT '',
+      p_actions text DEFAULT NULL,
+      p_country text DEFAULT NULL,
+      p_region text DEFAULT NULL,
+      p_city text DEFAULT NULL,
+      p_operatingsystemname text DEFAULT NULL,
+      p_devicemodel text DEFAULT NULL,
+      p_devicebrand text DEFAULT NULL,
+      p_visitduration text DEFAULT NULL,
+      p_dayssincefirstvisit text DEFAULT NULL,
+      p_visitortype text DEFAULT NULL,
+      p_sitename text DEFAULT NULL,
+      p_userid text DEFAULT NULL,
+      p_serverdateprettyfirstaction date DEFAULT NULL,
+      p_action_type text DEFAULT '',
+      p_action_eventcategory text DEFAULT '',
+      p_action_eventaction text DEFAULT '',
+      p_action_eventname text DEFAULT '',
+      p_action_eventvalue numeric DEFAULT 0,
+      p_action_timespent text DEFAULT '0',
+      p_usercustomproperties json DEFAULT NULL,
+      p_usercustomdimensions json DEFAULT NULL,
+      p_dimension1 text DEFAULT NULL,
+      p_dimension2 text DEFAULT NULL,
+      p_dimension3 text DEFAULT NULL,
+      p_dimension4 text DEFAULT NULL,
+      p_dimension5 text DEFAULT NULL,
+      p_dimension6 text DEFAULT NULL,
+      p_dimension7 text DEFAULT NULL,
+      p_dimension8 text DEFAULT NULL,
+      p_dimension9 text DEFAULT NULL,
+      p_dimension10 text DEFAULT NULL,
+      p_action_url text DEFAULT NULL,
+      p_sitesearchkeyword text DEFAULT NULL,
+      p_action_title text DEFAULT NULL,
+      p_visitorid text DEFAULT NULL,
+      p_referrertype text DEFAULT NULL,
+      p_referrername text DEFAULT NULL,
+      p_resolution text DEFAULT NULL,
+      p_experiments jsonb DEFAULT NULL
+    )
+    RETURNS void
+    LANGUAGE plpgsql
+    SECURITY INVOKER
+    AS $$
+    BEGIN
+        PERFORM create_weekly_partition_if_not_exists('${sql.raw(PARTITIONED_MATOMO_TABLE_NAME)}', p_action_timestamp);
+
+        INSERT INTO ${sql.id(PARTITIONED_MATOMO_TABLE_NAME)} (
+          action_id,
+          action_timestamp,
+          idsite,
+          idvisit,
+          actions,
+          country,
+          region,
+          city,
+          operatingsystemname,
+          devicemodel,
+          devicebrand,
+          visitduration,
+          dayssincefirstvisit,
+          visitortype,
+          sitename,
+          userid,
+          serverdateprettyfirstaction,
+          action_type,
+          action_eventcategory,
+          action_eventaction,
+          action_eventname,
+          action_eventvalue,
+          action_timespent,
+          usercustomproperties,
+          usercustomdimensions,
+          dimension1,
+          dimension2,
+          dimension3,
+          dimension4,
+          dimension5,
+          dimension6,
+          dimension7,
+          dimension8,
+          dimension9,
+          dimension10,
+          action_url,
+          sitesearchkeyword,
+          action_title,
+          visitorid,
+          referrertype,
+          referrername,
+          resolution,
+          experiments
+        ) VALUES (
+          p_action_id,
+          p_action_timestamp,
+          p_idsite,
+          p_idvisit,
+          p_actions,
+          p_country,
+          p_region,
+          p_city,
+          p_operatingsystemname,
+          p_devicemodel,
+          p_devicebrand,
+          p_visitduration,
+          p_dayssincefirstvisit,
+          p_visitortype,
+          p_sitename,
+          p_userid,
+          p_serverdateprettyfirstaction,
+          p_action_type,
+          p_action_eventcategory,
+          p_action_eventaction,
+          p_action_eventname,
+          p_action_eventvalue,
+          p_action_timespent,
+          p_usercustomproperties,
+          p_usercustomdimensions,
+          p_dimension1,
+          p_dimension2,
+          p_dimension3,
+          p_dimension4,
+          p_dimension5,
+          p_dimension6,
+          p_dimension7,
+          p_dimension8,
+          p_dimension9,
+          p_dimension10,
+          p_action_url,
+          p_sitesearchkeyword,
+          p_action_title,
+          p_visitorid,
+          p_referrertype,
+          p_referrername,
+          p_resolution,
+          p_experiments
+        )
+        ON CONFLICT (action_id, action_timestamp) DO NOTHING;
+    END;
+    $$;
+  `.execute(db)
 }
 
 export async function down(db: Kysely<any>): Promise<void> {
+  // Drop the new version of the stored procedure
+  await sql`DROP FUNCTION IF EXISTS insert_into_matomo_partitioned(
+    text, timestamptz, text, text, text, text, text, text, text, text, text,
+    text, text, text, text, text, date, text, text, text, text, numeric, text,
+    json, json, text, text, text, text, text, text, text, text, text, text,
+    text, text, text, text, text, text, text, jsonb
+  )`.execute(db)
+
+  // Restore the previous version (without experiments) so the downgrade is usable
+  await sql`
+    CREATE OR REPLACE FUNCTION insert_into_matomo_partitioned(
+      p_action_id text,
+      p_action_timestamp timestamptz,
+      p_idsite text DEFAULT '',
+      p_idvisit text DEFAULT '',
+      p_actions text DEFAULT NULL,
+      p_country text DEFAULT NULL,
+      p_region text DEFAULT NULL,
+      p_city text DEFAULT NULL,
+      p_operatingsystemname text DEFAULT NULL,
+      p_devicemodel text DEFAULT NULL,
+      p_devicebrand text DEFAULT NULL,
+      p_visitduration text DEFAULT NULL,
+      p_dayssincefirstvisit text DEFAULT NULL,
+      p_visitortype text DEFAULT NULL,
+      p_sitename text DEFAULT NULL,
+      p_userid text DEFAULT NULL,
+      p_serverdateprettyfirstaction date DEFAULT NULL,
+      p_action_type text DEFAULT '',
+      p_action_eventcategory text DEFAULT '',
+      p_action_eventaction text DEFAULT '',
+      p_action_eventname text DEFAULT '',
+      p_action_eventvalue numeric DEFAULT 0,
+      p_action_timespent text DEFAULT '0',
+      p_usercustomproperties json DEFAULT NULL,
+      p_usercustomdimensions json DEFAULT NULL,
+      p_dimension1 text DEFAULT NULL,
+      p_dimension2 text DEFAULT NULL,
+      p_dimension3 text DEFAULT NULL,
+      p_dimension4 text DEFAULT NULL,
+      p_dimension5 text DEFAULT NULL,
+      p_dimension6 text DEFAULT NULL,
+      p_dimension7 text DEFAULT NULL,
+      p_dimension8 text DEFAULT NULL,
+      p_dimension9 text DEFAULT NULL,
+      p_dimension10 text DEFAULT NULL,
+      p_action_url text DEFAULT NULL,
+      p_sitesearchkeyword text DEFAULT NULL,
+      p_action_title text DEFAULT NULL,
+      p_visitorid text DEFAULT NULL,
+      p_referrertype text DEFAULT NULL,
+      p_referrername text DEFAULT NULL,
+      p_resolution text DEFAULT NULL
+    )
+    RETURNS void
+    LANGUAGE plpgsql
+    SECURITY INVOKER
+    AS $$
+    BEGIN
+        PERFORM create_weekly_partition_if_not_exists('${sql.raw(PARTITIONED_MATOMO_TABLE_NAME)}', p_action_timestamp);
+
+        INSERT INTO ${sql.id(PARTITIONED_MATOMO_TABLE_NAME)} (
+          action_id,
+          action_timestamp,
+          idsite,
+          idvisit,
+          actions,
+          country,
+          region,
+          city,
+          operatingsystemname,
+          devicemodel,
+          devicebrand,
+          visitduration,
+          dayssincefirstvisit,
+          visitortype,
+          sitename,
+          userid,
+          serverdateprettyfirstaction,
+          action_type,
+          action_eventcategory,
+          action_eventaction,
+          action_eventname,
+          action_eventvalue,
+          action_timespent,
+          usercustomproperties,
+          usercustomdimensions,
+          dimension1,
+          dimension2,
+          dimension3,
+          dimension4,
+          dimension5,
+          dimension6,
+          dimension7,
+          dimension8,
+          dimension9,
+          dimension10,
+          action_url,
+          sitesearchkeyword,
+          action_title,
+          visitorid,
+          referrertype,
+          referrername,
+          resolution
+        ) VALUES (
+          p_action_id,
+          p_action_timestamp,
+          p_idsite,
+          p_idvisit,
+          p_actions,
+          p_country,
+          p_region,
+          p_city,
+          p_operatingsystemname,
+          p_devicemodel,
+          p_devicebrand,
+          p_visitduration,
+          p_dayssincefirstvisit,
+          p_visitortype,
+          p_sitename,
+          p_userid,
+          p_serverdateprettyfirstaction,
+          p_action_type,
+          p_action_eventcategory,
+          p_action_eventaction,
+          p_action_eventname,
+          p_action_eventvalue,
+          p_action_timespent,
+          p_usercustomproperties,
+          p_usercustomdimensions,
+          p_dimension1,
+          p_dimension2,
+          p_dimension3,
+          p_dimension4,
+          p_dimension5,
+          p_dimension6,
+          p_dimension7,
+          p_dimension8,
+          p_dimension9,
+          p_dimension10,
+          p_action_url,
+          p_sitesearchkeyword,
+          p_action_title,
+          p_visitorid,
+          p_referrertype,
+          p_referrername,
+          p_resolution
+        )
+        ON CONFLICT (action_id, action_timestamp) DO NOTHING;
+    END;
+    $$;
+  `.execute(db)
+
   // Drop column for AB Testing
   await db.schema
     .alterTable(MATOMO_TABLE_NAME)

--- a/src/migrations/20260407-01-ab-testing.ts
+++ b/src/migrations/20260407-01-ab-testing.ts
@@ -1,0 +1,29 @@
+import { Kysely } from 'kysely'
+
+const MATOMO_TABLE_NAME = process.env.MATOMO_TABLE_NAME || 'matomo'
+const PARTITIONED_MATOMO_TABLE_NAME =
+  process.env.PARTITIONED_MATOMO_TABLE_NAME || 'matomo_partitioned'
+
+export async function up(db: Kysely<any>): Promise<void> {
+  // Add column for AB Testing
+  await db.schema
+    .alterTable(MATOMO_TABLE_NAME)
+    .addColumn('experiments', 'jsonb')
+    .execute()
+  await db.schema
+    .alterTable(PARTITIONED_MATOMO_TABLE_NAME)
+    .addColumn('experiments', 'jsonb')
+    .execute()
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  // Drop column for AB Testing
+  await db.schema
+    .alterTable(MATOMO_TABLE_NAME)
+    .dropColumn('experiments')
+    .execute()
+  await db.schema
+    .alterTable(PARTITIONED_MATOMO_TABLE_NAME)
+    .dropColumn('experiments')
+    .execute()
+}


### PR DESCRIPTION
Ajout des données sur l'A/B Testing de Matomo. 

Le champ experiments contient les variants de la visite, exemple :
 
```json
[{"name": "search_ab_test", "variation": {"name": "search_v2", "idvariation": 5}, "idexperiment": "3"}] 
```

J'insère les données dans un champ jsonb pour faciliter les requêtes.